### PR TITLE
Corrected spelling of "sensor", and made code Python3 compatible

### DIFF
--- a/lightsensor.py
+++ b/lightsensor.py
@@ -1,7 +1,7 @@
 from lib.mBot import *
 
 def onLight(value):
-	print "light = ",value
+	print("light = ",value)
 	
 if __name__ == '__main__':
 	bot = mBot()


### PR DESCRIPTION
"lightsensor", not "lightsenser" - this is how it is referred to in doc's
enclosed print function arguments in brackets for Python3 compatibility
